### PR TITLE
Remove support for Debian 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
   - distro: ubuntu1810
   - distro: centos6
   - distro: centos7
-  # - distro: debian7
   - distro: debian8
   - distro: debian9
   - distro: debian10

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        # - wheezy
         - jessie
         - stretch
         - buster


### PR DESCRIPTION
#13 - Routine support to remove support for Debian 7 (Wheezy)